### PR TITLE
Fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "builder:gen": "ts-node --project olivela/scripts/tsconfig.scripts.json --require tsconfig-paths/register olivela/scripts/generate-builder-registry.ts",
+    "builder:gen": "ts-node --project scripts/tsconfig.scripts.json --require tsconfig-paths/register scripts/generate-builder-registry.ts",
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",

--- a/scripts/tsconfig.scripts.json
+++ b/scripts/tsconfig.scripts.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../tsconfig.json",
   "compilerOptions": {
     "module": "NodeNext",
     "moduleResolution": "NodeNext",

--- a/src/builder/registry.ts
+++ b/src/builder/registry.ts
@@ -1,0 +1,155 @@
+import { Builder } from "@builder.io/react";
+import { DevLinkProvider } from "@/devlink/DevLinkProvider";
+Builder.registerComponent(DevLinkProvider, {
+  name: "DevLinkProvider",
+});
+
+import { GlobalCodeEmbed } from "@/devlink/GlobalCodeEmbed";
+Builder.registerComponent(GlobalCodeEmbed, {
+  name: "GlobalCodeEmbed",
+});
+
+import { HomepageHero } from "@/devlink/HomepageHero";
+Builder.registerComponent(HomepageHero, {
+  name: "HomepageHero",
+});
+
+import { OliveButton } from "@/devlink/OliveButton";
+Builder.registerComponent(OliveButton, {
+  name: "OliveButton",
+});
+
+import { OliveFooter } from "@/devlink/OliveFooter";
+Builder.registerComponent(OliveFooter, {
+  name: "OliveFooter",
+});
+
+import { OliveNav } from "@/devlink/OliveNav";
+Builder.registerComponent(OliveNav, {
+  name: "OliveNav",
+});
+
+import { OliveSmallButton } from "@/devlink/OliveSmallButton";
+Builder.registerComponent(OliveSmallButton, {
+  name: "OliveSmallButton",
+});
+
+import { SectionBlogContentTeaser } from "@/devlink/SectionBlogContentTeaser";
+Builder.registerComponent(SectionBlogContentTeaser, {
+  name: "SectionBlogContentTeaser",
+});
+
+import { SectionCommonQuestions } from "@/devlink/SectionCommonQuestions";
+Builder.registerComponent(SectionCommonQuestions, {
+  name: "SectionCommonQuestions",
+});
+
+import { SectionContact } from "@/devlink/SectionContact";
+Builder.registerComponent(SectionContact, {
+  name: "SectionContact",
+});
+
+import { SectionEvents } from "@/devlink/SectionEvents";
+Builder.registerComponent(SectionEvents, {
+  name: "SectionEvents",
+});
+
+import { SectionFeatures } from "@/devlink/SectionFeatures";
+Builder.registerComponent(SectionFeatures, {
+  name: "SectionFeatures",
+});
+
+import { SectionPersonalizeCta } from "@/devlink/SectionPersonalizeCta";
+Builder.registerComponent(SectionPersonalizeCta, {
+  name: "SectionPersonalizeCta",
+});
+
+import { SectionReviews } from "@/devlink/SectionReviews";
+Builder.registerComponent(SectionReviews, {
+  name: "SectionReviews",
+});
+
+import { SectionSuiteLife } from "@/devlink/SectionSuiteLife";
+Builder.registerComponent(SectionSuiteLife, {
+  name: "SectionSuiteLife",
+});
+
+import { SingleHeadingCtaWithButton } from "@/devlink/SingleHeadingCtaWithButton";
+Builder.registerComponent(SingleHeadingCtaWithButton, {
+  name: "SingleHeadingCtaWithButton",
+});
+
+import { DevLinkContext } from "@/devlink/devlinkContext";
+Builder.registerComponent(DevLinkContext, {
+  name: "DevLinkContext",
+});
+
+import { EASING_FUNCTIONS } from "@/devlink/utils";
+Builder.registerComponent(EASING_FUNCTIONS, {
+  name: "EASING_FUNCTIONS",
+});
+
+import { BackgroundVideoWrapper } from "@/devlink/_Builtin/BackgroundVideo";
+Builder.registerComponent(BackgroundVideoWrapper, {
+  name: "BackgroundVideoWrapper",
+});
+
+import { Block } from "@/devlink/_Builtin/Basic";
+Builder.registerComponent(Block, {
+  name: "Block",
+});
+
+import { DropdownWrapper } from "@/devlink/_Builtin/Dropdown";
+Builder.registerComponent(DropdownWrapper, {
+  name: "DropdownWrapper",
+});
+
+import { Facebook } from "@/devlink/_Builtin/Facebook";
+Builder.registerComponent(Facebook, {
+  name: "Facebook",
+});
+
+import { FormWrapper } from "@/devlink/_Builtin/Form";
+Builder.registerComponent(FormWrapper, {
+  name: "FormWrapper",
+});
+
+import { MapWidget } from "@/devlink/_Builtin/Map";
+Builder.registerComponent(MapWidget, {
+  name: "MapWidget",
+});
+
+import { NavbarContext } from "@/devlink/_Builtin/Navbar";
+Builder.registerComponent(NavbarContext, {
+  name: "NavbarContext",
+});
+
+import { SliderContext } from "@/devlink/_Builtin/Slider";
+Builder.registerComponent(SliderContext, {
+  name: "SliderContext",
+});
+
+import { TabsWrapper } from "@/devlink/_Builtin/Tabs";
+Builder.registerComponent(TabsWrapper, {
+  name: "TabsWrapper",
+});
+
+import { Twitter } from "@/devlink/_Builtin/Twitter";
+Builder.registerComponent(Twitter, {
+  name: "Twitter",
+});
+
+import { Heading } from "@/devlink/_Builtin/Typography";
+Builder.registerComponent(Heading, {
+  name: "Heading",
+});
+
+import { Video } from "@/devlink/_Builtin/Video";
+Builder.registerComponent(Video, {
+  name: "Video",
+});
+
+import { YouTubeVideo } from "@/devlink/_Builtin/YouTubeVideo";
+Builder.registerComponent(YouTubeVideo, {
+  name: "YouTubeVideo",
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,9 @@
     "baseUrl": ".",
     "outDir": "dist",
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./src/*"],
+      "@/devlink": ["src/devlink/components"],
+      "@/devlink/*": ["src/devlink/components/*"]
     },
     "plugins": [
       {


### PR DESCRIPTION
## Summary by Sourcery

Add TS path mappings for the devlink components and streamline the builder generation script by moving it to the top-level scripts folder

Enhancements:
- Add TypeScript path aliases for devlink components under "@/devlink"
- Update builder:gen script to reference the new top-level scripts directory