### PR TITLE
Commit

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,15 @@
-import type { NextConfig } from "next";
+// next.config.ts
+import type { NextConfig } from 'next';
+import path from 'path';
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  webpack(config) {
+    config.resolve.alias = {
+      ...(config.resolve.alias || {}),
+      '@': path.resolve(__dirname, 'src'),
+    };
+    return config;
+  },
 };
 
 export default nextConfig;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,12 +13,12 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",
-    "baseUrl": ".",
+    "baseUrl": "src",
     "outDir": "dist",
     "paths": {
-      "@/*": ["./src/*"],
-      "@/devlink": ["src/devlink/components"],
-      "@/devlink/*": ["src/devlink/components/*"]
+      "@/*": ["*"],
+      "@/devlink": ["devlink/components"],
+      "@/devlink/*": ["devlink/components/*"]
     },
     "plugins": [
       {


### PR DESCRIPTION
## Summary by Sourcery

Configure consistent module resolution by adding a '@' alias in Next.js webpack config and aligning tsconfig baseUrl and path mappings to the src directory

Enhancements:
- Add webpack alias '@' pointing to the src directory in next.config.ts

Build:
- Set tsconfig baseUrl to 'src' and update path mappings for '@/...' to match the webpack alias